### PR TITLE
Change send function to middleware

### DIFF
--- a/lib/jsonParser.js
+++ b/lib/jsonParser.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Function populates the req.body with JSON data.
-module.exports = exports = function JSONparser(req) {
+module.exports = exports = function jsonParser(req) {
   let content = '';
   req.on('data', (data) => {
     content += data.toString();

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,12 +1,14 @@
 'use strict';
 
-const jsonParser = require('./jsonParser.js');
+const jsonParser = require('./jsonParser');
+const resSend = require('./resSend');
 
 // Takes a router and returns a function that runs any middleware on requests
 // before calling the router.
 module.exports = exports = function middleware(router) {
   return (req, res) => {
     jsonParser(req);
+    resSend(req, res);
     req.on('end', () => {
       router.route(req, res);
     });

--- a/lib/resSend.js
+++ b/lib/resSend.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = exports = function send(req, res) {
+  res.send = function(message, type) {
+    let detectedType;
+    if (typeof message === 'object') {
+      detectedType = 'application/json';
+      message = JSON.stringify(message);
+    } else if (message.startsWith('<!DOCTYPE html>')) {
+      detectedType = 'text/html';
+    } else {
+      detectedType = 'text/plain';
+    }
+    type = type || detectedType;
+    this.writeHead(200, { 'Content-Type': type });
+    this.write(message);
+    this.end();
+  };
+};

--- a/lib/router.js
+++ b/lib/router.js
@@ -44,25 +44,6 @@ methods.forEach(method => {
 
 module.exports = exports = Router;
 
-function jsonParser(req) {
-  var content = '';
-  req.on('data', (data) => {
-    content += data.toString();
-  });
-  req.on('end', () => {
-    var parsedContent = JSON.stringify(content);
-    req.body = parsedContent;
-  });
-}
-
-Router.prototype.send = function(res, message) {
-  var type;
-  if (typeof message == 'object') type = 'application/json' ;             
-  else if (message.startsWith('<!DOCTYPE html>') ) type = 'text/html';    
-  else type = 'text/plain';                                               
-  writeRes(res, message, type);
-};
-
 // Write a message back.
 // If not specified the contentType will be application/json and the
 // status code will be 200

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "gulp-eslint": "^1.1.1",
     "gulp-mocha": "^2.2.0",
     "mocha": "^2.3.4"
+  },
+  "dependencies": {
+    "mime-types": "^2.1.9"
   }
 }

--- a/test/resSend.spec.js
+++ b/test/resSend.spec.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const middleware = require('../lib/middleware');
+const chai = require('chai');
+const http = require('http');
+chai.use(require('chai-http'));
+const expect = chai.expect;
+
+/* eslint-disable no-unused-expressions */
+
+describe('res.send()', () => {
+  it('should write a plain text response', (done) => {
+    let called = 0;
+    const testRes = {
+      writeHead: (code, contentType) => {
+        called++;
+        expect(code).to.eql(200);
+        expect(contentType).to.be.an('object');
+        expect(contentType['Content-Type']).to.eql('text/plain');
+      },
+      write: message => {
+        called++;
+        expect(message).to.be.a('string');
+        expect(message).to.eql('Hello World!');
+      },
+      end: () => {
+        called++;
+      }
+    };
+    const testRouter = {
+      route: (req, res) => {
+        for (let prop in testRes) {
+          if (testRes.hasOwnProperty(prop)) {
+            res['super' + prop] = res[prop];
+            res[prop] = testRes[prop];
+          }
+        }
+        res.send('Hello World!');
+        expect(called).to.eql(3);
+        done();
+      }
+    };
+    this.server = http.createServer(middleware(testRouter)).listen(3030);
+    chai.request('localhost:3030')
+      .post('/test')
+      .send({ 'test': 'test' })
+      .end(() => {
+        done();
+      });
+  });
+
+  it('should write a json response', (done) => {
+    let called = 0;
+    const testRes = {
+      writeHead: (code, contentType) => {
+        called++;
+        expect(code).to.eql(200);
+        expect(contentType).to.be.an('object');
+        expect(contentType['Content-Type']).to.eql('application/json');
+      },
+      write: message => {
+        called++;
+        expect(message).to.be.a('string');
+        expect(message).to.eql('{"msg":"Hello World!"}');
+      },
+      end: () => {
+        called++;
+      }
+    };
+    const testRouter = {
+      route: (req, res) => {
+        for (let prop in testRes) {
+          if (testRes.hasOwnProperty(prop)) {
+            res['super' + prop] = res[prop];
+            res[prop] = testRes[prop];
+          }
+        }
+        res.send({ 'msg': 'Hello World!' });
+        expect(called).to.eql(3);
+        done();
+      }
+    };
+    this.server = http.createServer(middleware(testRouter)).listen(3030);
+    chai.request('localhost:3030')
+      .post('/test')
+      .send({ 'test': 'test' })
+      .end(() => {
+        done();
+      });
+  });
+  afterEach(() => {
+    this.server.close();
+  });
+});


### PR DESCRIPTION
- Changes the `send` function to middleware to that it can be injected into the `res` object.
- Adds a test for the JSON and plaintext versions of that function. Test for HTML version is pending.
