### PR TITLE
Static checks if path is a file or folder and returns a promise

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -1,8 +1,10 @@
 'use strict';
 
-const methods = ['GET', 'POST', 'PUSH', 'PATCH', 'DELETE'];
 const fs = require('fs');
+const path = require('path');
 const mime = require('mime-types');
+
+const methods = ['GET', 'POST', 'PUSH', 'PATCH', 'DELETE'];
 
 const Router = function() {
   this.routes =
@@ -19,31 +21,57 @@ Router.prototype.route = function(req, res) {
   return endpoint(req, res);
 };
 
-// static prototype serves up files in a specified directory
-Router.prototype.static = function(dir) {
-  const method = 'GET';
-  fs.readdir(dir, (err, data) => {
-    if (err) return 'Error reading directory.';
-    data.forEach((url) => {
-      this.routes[method][url] = (req, res) => {
-        fs.readFile(url, (err, file) => {
-          // mime.lookup(file);
-          if (err) return 'Error reading file.';
-          var contentType = mime.lookup(file);
-          res.writeHead(200, { 'Content-Type': contentType });
-          res.write(file);
-        });
-      };
-    });
-  });
-};
-
 methods.forEach(method => {
   Router.prototype[method.toLowerCase()] = function(url, callback) {
     this.routes[method][url] = callback;
     return this;
   };
 });
+
+// static prototype serves up files in a specified directory
+Router.prototype.static = function(dir) {
+  return new Promise((resolve, reject) => {
+    const directory = path.resolve(__dirname, dir);
+    fs.readdir(directory, (err, files) => {
+      if (err) {
+        console.log('Error reading directory: ' + dir);
+        return reject(err);
+      }
+      for (let i = 0; i < files.length; i++) {
+        const url = files[i];
+        const filepath = path.join(directory, url);
+
+        fs.stat(filepath, (err, stats) => {
+          if (err) {
+            console.log('Error getting stats for: ' + filepath);
+            reject(err);
+          }
+          if (stats.isFile()) {
+            this.routes.GET['/' + url] = (req, res) => {
+              return new Promise((resolve, reject) => {
+                const contentType =
+                  mime.contentType(url) || 'application/octet-stream';
+                fs.readFile(filepath, (err, data) => {
+                  if (err) {
+                    console.log(err);
+                    reject('error reading file: ' + filepath);
+                  }
+                  res.writeHead(200, { 'Content-Type': contentType });
+                  res.write(data.toString());
+                  res.end();
+                  resolve();
+                });
+              });
+            };
+          }
+          // if finished final async op, resolve Promise
+          if (i === files.length - 1) resolve();
+        });
+
+      }
+    });
+  });
+};
 
 module.exports = exports = Router;
 

--- a/test/static.spec.js
+++ b/test/static.spec.js
@@ -1,20 +1,115 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
 const expect = require('chai').expect;
 const Router = require('../lib/router');
 
-describe('Router', () => {
-  it('should be able to register a route', () => {
+/* eslint-disable no-unused-expressions, no-sync */
+
+describe('static routing', () => {
+  const testDir = path.join(__dirname, 'testfiles');
+  before(() => {
+    if (!fs.existsSync(testDir)) fs.mkdirSync(testDir);
+    try {
+      fs.writeFileSync(path.join(testDir, 'test.md'), '# Hello World');
+      fs.writeFileSync(path.join(testDir, 'test.json'), '{"Hello":"World"}');
+      fs.mkdir(path.join(testDir, 'emptyDir'));
+    } catch (e) {
+      console.log('File creation error in static routing tests');
+    }
+  });
+
+  it('should return markdown content-type', (done) => {
+    let called = 0;
+    const testRes = {
+      writeHead(statusCode, headers) {
+        called++;
+        expect(statusCode).to.equal(200);
+        expect(headers).to.have.property('Content-Type');
+        expect(headers['Content-Type'])
+          .to.eql('text/x-markdown; charset=utf-8');
+      },
+      write(message) {
+        called++;
+        expect(message).to.equal('# Hello World');
+      },
+      end() {
+        called++;
+      }
+    };
     const router = new Router();
-    const testReq = { method: 'GET', dir: './public' };
-    let cbFired = false;
-    router.static(testReq.dir, (req, res) => {
-      cbFired = true;
-      expect(req.method).to.eql(testReq.method);
-      expect(req.dir).to.eql(testReq.dir);
-      expect(res.text).to.eql()
+    router.static(testDir)
+      .then(() => {
+        router.route({ method: 'GET', url: '/test.md' }, testRes)
+        .then(() => {
+          expect(called).to.eql(3);
+          done();
+        });
+      });
+  });
+
+  it('should return json content-type', (done) => {
+    let called = 0;
+    const testRes = {
+      writeHead(statusCode, headers) {
+        called++;
+        expect(statusCode).to.equal(200);
+        expect(headers).to.have.property('Content-Type');
+        expect(headers['Content-Type'])
+          .to.eql('application/json; charset=utf-8');
+      },
+      write(message) {
+        called++;
+        expect(message).to.equal('{"Hello":"World"}');
+      },
+      end() {
+        called++;
+      }
+    };
+    const router = new Router();
+    router.static(testDir)
+      .then(() => {
+        router.route({ method: 'GET', url: '/test.json' }, testRes)
+        .then(() => {
+          expect(called).to.eql(3);
+          done();
+        });
+      });
+  });
+
+  it('should not register a route for directories', (done) => {
+    let called = 0;
+    const testRes = {
+      writeHead(statusCode, headers) {
+        expect(statusCode).to.equal(404);
+        expect(headers).to.have.property('Content-Type');
+        expect(headers['Content-Type']).to.eql('text/plain');
+        called++;
+      },
+      end(message) {
+        expect(message).to.equal('404 Not Found');
+        called++;
+      }
+    };
+    const router = new Router();
+    router.static(testDir)
+      .then(() => {
+        router.route({ method: 'GET', url: '/emptyDir' }, testRes);
+        expect(called).to.eql(2);
+        done();
+      });
+  });
+
+  after(() => {
+    fs.readdirSync(testDir).forEach((file) => {
+      const currPath = path.join(testDir, file);
+      if (fs.statSync(currPath).isFile()) {
+        fs.unlinkSync(path.join(testDir, file));
+        return;
+      }
+      fs.rmdirSync(currPath);
     });
-    router.route()(testReq, null);
-    expect(cbFired).to.be.true;
+    fs.rmdir(testDir);
   });
 });


### PR DESCRIPTION
Does what the title says + adds tests for various static routing scenarios.

Had to wrap pieces of the static router in promises in order to facilitate testing, or else I was running into async induced errors.
